### PR TITLE
Fixed an issue where the 'contact ID' was being created incorrectly - th...

### DIFF
--- a/Box2D.NET/Collision/ContactID.cs
+++ b/Box2D.NET/Collision/ContactID.cs
@@ -92,7 +92,7 @@ namespace Box2D.Collision
         public void Set(ContactID c)
         {
             IndexA = c.IndexA;
-            IndexB = c.IndexA;
+            IndexB = c.IndexB;
             TypeA = c.TypeA;
             TypeB = c.TypeB;
         }


### PR DESCRIPTION
...is was causing duplicate manifolds to not be recognised and objects to 'slide' continually against each other when stacked. The fix makes the simulation much more stable
